### PR TITLE
Improve SpamScoreTracker plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+spam_score_tracker.tar.gz
+logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENT INSTRUCTIONS
+For all code changes in this repository:
+- Run `php -l spam_score_tracker/public_html/index.php` to check PHP syntax.
+- If packaging is needed, run `./build_plugin.sh` to create `spam_score_tracker.tar.gz`, but do not commit the archive.

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Create an archive of the plugin for easy upload
+
+tar -czf spam_score_tracker.tar.gz spam_score_tracker

--- a/spam_score_tracker/README.md
+++ b/spam_score_tracker/README.md
@@ -1,0 +1,24 @@
+# SpamScoreTracker DirectAdmin Plugin
+
+This plugin provides a simple interface for DirectAdmin administrators to review SpamAssassin scores for incoming email. It parses the Exim mail log and lists the score for each message, recording extra details such as the subject, message ID, size, and whether the message was delivered or rejected.
+
+*Requires the Evolution skin.*
+
+## Installation
+
+1. Copy the `spam_score_tracker` directory to `/usr/local/directadmin/plugins/`.
+2. Run the provided `install.sh` script from inside the directory to create the log folder and set permissions.
+3. Ensure the directory ownership is `diradmin:diradmin` if not already set.
+4. Log in to DirectAdmin as admin and navigate to *Plugins* to enable **SpamScoreTracker**.
+
+To remove the plugin cleanly, run `./uninstall.sh` from the plugin directory before deleting it.
+
+The plugin parses `/var/log/exim/mainlog`. Adjust the path in `public_html/index.php` if your Exim log is located elsewhere. Parsed results are written to `logs/scores.log` inside the plugin directory for later review. Each line of the CSV file includes the date, message ID, sender, recipients, IP, score, subject, message ID, size, the raw SpamAssassin line, and whether the message was delivered or rejected.
+
+### Packaging
+
+The repository does not include the plugin archive. To create `spam_score_tracker.tar.gz` for upload, run:
+
+```sh
+./build_plugin.sh
+```

--- a/spam_score_tracker/admin/index.html
+++ b/spam_score_tracker/admin/index.html
@@ -1,0 +1,4 @@
+#!/usr/local/bin/php
+<?php
+require_once __DIR__ . '/../public_html/index.php';
+?>

--- a/spam_score_tracker/evolution/menu.html
+++ b/spam_score_tracker/evolution/menu.html
@@ -1,0 +1,3 @@
+<li>
+  <a href="/CMD_PLUGINS/spam_score_tracker/">Spam Score Tracker</a>
+</li>

--- a/spam_score_tracker/hooks/admin_txt.html
+++ b/spam_score_tracker/hooks/admin_txt.html
@@ -1,0 +1,1 @@
+<a href="/CMD_PLUGINS_ADMIN/spam_score_tracker">Spam Score Tracker</a>

--- a/spam_score_tracker/install.sh
+++ b/spam_score_tracker/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Install script for SpamScoreTracker
+PLUGIN_DIR=$(dirname "$0")
+
+# Ensure log directory exists
+mkdir -p "$PLUGIN_DIR/logs"
+
+# Ensure admin page is executable
+chmod 755 "$PLUGIN_DIR/admin/index.html"
+
+# Set ownership so DirectAdmin can write
+chown -R diradmin:diradmin "$PLUGIN_DIR"
+
+exit 0

--- a/spam_score_tracker/plugin.conf
+++ b/spam_score_tracker/plugin.conf
@@ -1,0 +1,9 @@
+name=SpamScoreTracker
+id=spam_score_tracker
+author=Codex
+version=1.0
+desc=Track SpamAssassin scores for received emails
+skins=evolution
+active=yes
+installed=yes
+user=admin

--- a/spam_score_tracker/public_html/index.php
+++ b/spam_score_tracker/public_html/index.php
@@ -1,0 +1,137 @@
+<?php
+// SpamScoreTracker admin page
+// Only accessible to admin user
+if (!isset($_SERVER['REMOTE_USER']) || $_SERVER['REMOTE_USER'] !== 'admin') {
+    header('HTTP/1.1 403 Forbidden');
+    echo 'Access denied';
+    exit;
+}
+
+// Path to Exim main log (adjust if necessary)
+$logFile = '/var/log/exim/mainlog';
+
+// Where to store parsed data
+$logOutput = __DIR__ . '/../logs/scores.log';
+
+function parse_log($file) {
+    if (!file_exists($file)) return [];
+    $fh = fopen($file, 'r');
+    if (!$fh) return [];
+    $msg = [];
+    while (($line = fgets($fh)) !== false) {
+        // message received line
+        if (preg_match('/^(\S+\s+\S+)\s+(\S+)\s+<=\s+(\S+).*\[(\d+\.\d+\.\d+\.\d+)\]/', $line, $m)) {
+            $id = $m[2];
+            $msg[$id]['time'] = $m[1];
+            $msg[$id]['from'] = $m[3];
+            $msg[$id]['ip'] = $m[4];
+            if (preg_match('/T="([^"]*)"/', $line, $ms)) {
+                $msg[$id]['subject'] = $ms[1];
+            }
+            if (preg_match('/id=([^\s]+)/', $line, $mi)) {
+                $msg[$id]['msgid'] = $mi[1];
+            }
+            if (preg_match('/S=(\d+)/', $line, $msz)) {
+                $msg[$id]['size'] = $msz[1];
+            }
+        }
+
+        // delivery lines
+        if (preg_match('/^(\S+\s+\S+)\s+(\S+)\s+=>\s+(\S+)/', $line, $m)) {
+            $id = $m[2];
+            $msg[$id]['to'][] = $m[3];
+        }
+
+        // completed delivery line
+        if (preg_match('/^(\S+\s+\S+)\s+(\S+)\s+Completed/', $line, $m)) {
+            $id = $m[2];
+            $msg[$id]['action'] = $msg[$id]['action'] ?? 'delivered';
+        }
+
+        // rejection line
+        if (preg_match('/^(\S+\s+\S+)\s+(\S+).*rejected/i', $line, $m)) {
+            $id = $m[2];
+            $msg[$id]['action'] = 'rejected';
+        }
+
+        // spam score line
+        if (preg_match('/^(\S+\s+\S+)\s+(\S+)\s+spamcheck: score=([\d\.\-]+)/i', $line, $m)) {
+            $id = $m[2];
+            $msg[$id]['time'] = $msg[$id]['time'] ?? $m[1];
+            $msg[$id]['score'] = floatval($m[3]);
+            $msg[$id]['spamline'] = trim($line);
+        }
+    }
+    fclose($fh);
+    return $msg;
+}
+
+
+$scores = parse_log($logFile);
+
+// Determine action for each message based on log lines
+foreach ($scores as $id => $info) {
+    if (!empty($info['action'])) continue;
+    $scores[$id]['action'] = 'delivered';
+}
+
+// Write the parsed data to a log file for later review
+if (!empty($scores)) {
+    if (!is_dir(dirname($logOutput))) {
+        mkdir(dirname($logOutput), 0755, true);
+    }
+    if ($fh = fopen($logOutput, 'a')) {
+        foreach ($scores as $id => $info) {
+            $to = isset($info['to']) ? implode(',', $info['to']) : '';
+            fputcsv($fh, [
+                $info['time'] ?? '',
+                $id,
+                $info['from'] ?? '',
+                $to,
+                $info['ip'] ?? '',
+                $info['score'] ?? '',
+                $info['subject'] ?? '',
+                $info['msgid'] ?? '',
+                $info['size'] ?? '',
+                $info['spamline'] ?? '',
+                $info['action'] ?? ''
+            ]);
+        }
+        fclose($fh);
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Spam Score Tracker</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { padding: 8px; border: 1px solid #ccc; }
+        th { background: #eee; }
+    </style>
+</head>
+<body>
+<h1>SpamAssassin Score History</h1>
+
+<table>
+    <tr><th>Date</th><th>ID</th><th>From</th><th>To</th><th>IP</th><th>Score</th><th>Subject</th><th>Message ID</th><th>Size</th><th>Action</th></tr>
+    <?php foreach ($scores as $id => $s): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($s['time'] ?? ''); ?></td>
+            <td><?php echo htmlspecialchars($id); ?></td>
+            <td><?php echo htmlspecialchars($s['from'] ?? ''); ?></td>
+            <td><?php echo htmlspecialchars(isset($s['to']) ? implode(',', $s['to']) : ''); ?></td>
+            <td><?php echo htmlspecialchars($s['ip'] ?? ''); ?></td>
+            <td><?php echo htmlspecialchars($s['score'] ?? ''); ?></td>
+            <td><?php echo htmlspecialchars($s['subject'] ?? ''); ?></td>
+            <td><?php echo htmlspecialchars($s['msgid'] ?? ''); ?></td>
+            <td><?php echo htmlspecialchars($s['size'] ?? ''); ?></td>
+            <td><?php echo htmlspecialchars($s['action'] ?? ''); ?></td>
+        </tr>
+    <?php endforeach; ?>
+</table>
+</body>
+</html>

--- a/spam_score_tracker/uninstall.sh
+++ b/spam_score_tracker/uninstall.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Uninstall script for SpamScoreTracker
+PLUGIN_DIR=$(dirname "$0")
+
+# Remove stored logs
+rm -rf "$PLUGIN_DIR/logs"
+
+exit 0


### PR DESCRIPTION
## Summary
- remove threshold-based stats and pie chart
- log message actions (delivered or rejected)
- add action column to output table and log
- document new fields in README

## Testing
- `php -l spam_score_tracker/public_html/index.php` *(fails: php not found)*
- `./build_plugin.sh` then removed generated archive

------
https://chatgpt.com/codex/tasks/task_e_686ba0c62f6483318c867f443366d057