### PR TITLE
Refactor plugin scripts and add update helper

### DIFF
--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
-# Create an archive of the plugin for easy upload
-cd spam_score_tracker
-tar -czf spam_score_tracker.tar.gz ./*
+# Create an archive of the plugin for easy upload.
+# The resulting spam_score_tracker.tar.gz is written to the repository root so
+# it is never included inside the archive itself.
+
+set -e
+
+PLUGIN_DIR="spam_score_tracker"
+OUTPUT="spam_score_tracker.tar.gz"
+
+# Ensure we start from the script directory
+cd "$(dirname "$0")"
+
+# Remove any existing archive to avoid nesting
+rm -f "$OUTPUT"
+
+# Create the archive from the plugin directory
+tar -czf "$OUTPUT" -C "$PLUGIN_DIR" .

--- a/spam_score_tracker/README.md
+++ b/spam_score_tracker/README.md
@@ -7,18 +7,20 @@ This plugin provides a simple interface for DirectAdmin administrators to review
 ## Installation
 
 1. Copy the `spam_score_tracker` directory to `/usr/local/directadmin/plugins/`.
-2. Run the provided `install.sh` script from inside the directory to create the log folder and set permissions.
+2. Run the provided `scripts/install.sh` script from inside the directory to create the log folder and set permissions.
 3. Ensure the directory ownership is `diradmin:diradmin` if not already set.
 4. Log in to DirectAdmin as admin and navigate to *Plugins* to enable **SpamScoreTracker**.
 
-To remove the plugin cleanly, run `./uninstall.sh` from the plugin directory before deleting it.
+To remove the plugin cleanly, run `./scripts/uninstall.sh` from the plugin directory before deleting it.
 
 The plugin parses `/var/log/exim/mainlog`. Adjust the path in `public_html/index.php` if your Exim log is located elsewhere. Parsed results are written to `logs/scores.log` inside the plugin directory for later review. Each line of the CSV file includes the date, message ID, sender, recipients, IP, score, subject, message ID, size, the raw SpamAssassin line, and whether the message was delivered or rejected.
 
 ### Packaging
 
-The repository does not include the plugin archive. To create `spam_score_tracker.tar.gz` for upload, run:
+The repository does not include the plugin archive. To create `spam_score_tracker.tar.gz` in the repository root for upload, run:
 
 ```sh
 ./build_plugin.sh
 ```
+
+An optional `update_plugin.sh` script is provided to rebuild and install the plugin on a local DirectAdmin server in one step.

--- a/spam_score_tracker/public_html/index.php
+++ b/spam_score_tracker/public_html/index.php
@@ -1,7 +1,9 @@
 <?php
 // SpamScoreTracker admin page
-// Only accessible to admin user
-if (!isset($_SERVER['REMOTE_USER']) || $_SERVER['REMOTE_USER'] !== 'admin') {
+// Only accessible to an administrator
+$user = $_SERVER['REMOTE_USER'] ?? '';
+$allowedAdmins = ['admin', 'diradmin'];
+if ($user === '' || !in_array($user, $allowedAdmins, true)) {
     header('HTTP/1.1 403 Forbidden');
     echo 'Access denied';
     exit;

--- a/spam_score_tracker/scripts/install.sh
+++ b/spam_score_tracker/scripts/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Install script for SpamScoreTracker
-PLUGIN_DIR=$(dirname "$0")
+SCRIPT_DIR=$(dirname "$0")
+PLUGIN_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # Ensure log directory exists
 mkdir -p "$PLUGIN_DIR/logs"

--- a/spam_score_tracker/scripts/uninstall.sh
+++ b/spam_score_tracker/scripts/uninstall.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Uninstall script for SpamScoreTracker
-PLUGIN_DIR=$(dirname "$0")
+SCRIPT_DIR=$(dirname "$0")
+PLUGIN_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # Remove stored logs
 rm -rf "$PLUGIN_DIR/logs"

--- a/update_plugin.sh
+++ b/update_plugin.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Convenience script to rebuild and install the plugin locally.
+
+set -e
+
+# Build the archive in the repository root
+./build_plugin.sh
+
+ARCHIVE="spam_score_tracker.tar.gz"
+PLUGIN_DIR="/usr/local/directadmin/plugins/spam_score_tracker"
+
+if [ -d "$PLUGIN_DIR" ]; then
+    echo "Removing existing plugin" >&2
+    if [ -x "$PLUGIN_DIR/scripts/uninstall.sh" ]; then
+        "$PLUGIN_DIR/scripts/uninstall.sh"
+    fi
+    rm -rf "$PLUGIN_DIR"
+fi
+
+mkdir -p /usr/local/directadmin/plugins
+
+echo "Extracting new version" >&2
+
+tar -xzf "$ARCHIVE" -C /usr/local/directadmin/plugins
+
+if [ -x "$PLUGIN_DIR/scripts/install.sh" ]; then
+    "$PLUGIN_DIR/scripts/install.sh"
+fi
+
+echo "Plugin updated"


### PR DESCRIPTION
## Summary
- move install/uninstall to `scripts/`
- write build output outside the plugin
- add helper script to build and deploy locally
- allow `diradmin` login in the PHP page
- document new paths and helper script

## Testing
- `php -l spam_score_tracker/public_html/index.php`


------
https://chatgpt.com/codex/tasks/task_e_686be83e9b548331a2c568f2b91d5001