### PR TITLE
Fix admin check in spam tracker

### DIFF
--- a/spam_score_tracker/public_html/index.php
+++ b/spam_score_tracker/public_html/index.php
@@ -1,7 +1,11 @@
 <?php
 // SpamScoreTracker admin page
 // Only accessible to an administrator
-$user = $_SERVER['REMOTE_USER'] ?? '';
+$user = $_SERVER['REMOTE_USER']
+    ?? $_SERVER['username']
+    ?? $_SERVER['USER']
+    ?? $_SERVER['user']
+    ?? '';
 $allowedAdmins = ['admin', 'diradmin'];
 if ($user === '' || !in_array($user, $allowedAdmins, true)) {
     header('HTTP/1.1 403 Forbidden');


### PR DESCRIPTION
## Summary
- extend admin check to use more DirectAdmin auth variables

## Testing
- `php -l spam_score_tracker/public_html/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bee063f5c833198785a8f346b6bc9