### PR TITLE
Integrate DB-backed tracking

### DIFF
--- a/spam_score_tracker/README.md
+++ b/spam_score_tracker/README.md
@@ -7,13 +7,15 @@ This plugin provides a simple interface for DirectAdmin administrators to review
 ## Installation
 
 1. Copy the `spam_score_tracker` directory to `/usr/local/directadmin/plugins/`.
-2. Run the provided `scripts/install.sh` script from inside the directory to create the log folder and set permissions.
+2. Run the provided `scripts/install.sh` script from inside the directory. The script creates the log folder, installs Python and required modules, sets up the `mail_logs` database (user `mail_logs`, password `l59X8bHfO07FIBWY08Z98`), and installs a systemd unit to keep the database updated from the mail logs.
 3. Ensure the directory ownership is `diradmin:diradmin` if not already set.
 4. Log in to DirectAdmin as admin and navigate to *Plugins* to enable **SpamScoreTracker**.
 
 To remove the plugin cleanly, run `./scripts/uninstall.sh` from the plugin directory before deleting it.
 
-By default the plugin reads `/var/log/exim/mainlog` and `/var/log/mail.log`.  Edit the `$logFiles` array in `public_html/index.php` if your logs are stored in different locations. Parsed results are written to `logs/scores.log` inside the plugin directory for later review. Each line of the CSV file includes the date, message ID, sender, recipients, IP, score, the triggered SpamAssassin tests, subject, message ID, size, the raw SpamAssassin line, and whether the message was delivered or rejected. The parser cross-references SpamAssassin logs with Exim entries by the email's Message-ID so that scores from `spamd` lines are matched to the correct delivery record.
+The included Python script continuously tails `/var/log/exim/mainlog` and `/var/log/mail.log` and stores each message's score along with the sender, recipients and subject in a MySQL table. The PHP interface simply reads from this database, so no log parsing is done on each page load.
+
+The web interface lets you choose how many results to display per page and offers page numbers to navigate through the history.
 
 ### Packaging
 
@@ -24,6 +26,29 @@ The repository does not include the plugin archive. To create `spam_score_tracke
 ```
 
 An optional `update_plugin.sh` script is provided to rebuild and install the plugin on a local DirectAdmin server in one step.
+
+### Command-line queries
+
+The `scripts/spam_score_tool.py` helper can store and retrieve scores in a
+MySQL database. Edit the `DB_CONFIG` section at the top of the script with your
+database credentials, then run:
+
+```sh
+python3 scripts/spam_score_tool.py backfill
+```
+to import any existing log entries. You can then look up a single message by
+ID and timestamp or start continuous tracking with:
+
+```sh
+python3 scripts/spam_score_tool.py follow
+```
+
+Once running, the service will keep the database in sync. You can still look up
+a single message manually:
+
+```sh
+python3 scripts/spam_score_tool.py query --mid "<message-id>" --time "YYYY/MM/DD HH:MM"
+```
 
 ## Troubleshooting
 

--- a/spam_score_tracker/scripts/install.sh
+++ b/spam_score_tracker/scripts/install.sh
@@ -5,11 +5,78 @@ PLUGIN_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # Ensure log directory exists
 mkdir -p "$PLUGIN_DIR/logs"
+chmod 775 "$PLUGIN_DIR/logs"
 
 # Ensure admin page is executable
 chmod 755 "$PLUGIN_DIR/admin/index.html"
 
 # Set ownership so DirectAdmin can write
 chown -R diradmin:diradmin "$PLUGIN_DIR"
+
+# Allow diradmin to read system log files (adm group usually has access)
+if id diradmin >/dev/null 2>&1; then
+    usermod -a -G adm diradmin 2>/dev/null || true
+fi
+
+# Install Python 3 if missing and ensure mysql-connector-python is available
+if ! command -v python3 >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update && apt-get install -y python3 python3-pip
+    elif command -v yum >/dev/null 2>&1; then
+        yum install -y python3 python3-pip
+    fi
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'EOF'
+import pkgutil, sys, subprocess
+if not pkgutil.find_loader('mysql.connector'):
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'mysql-connector-python'])
+EOF
+fi
+
+# Create MySQL database, user, and table if they don't exist
+mysql -u root <<'EOF'
+CREATE DATABASE IF NOT EXISTS mail_logs;
+CREATE USER IF NOT EXISTS 'mail_logs'@'localhost' IDENTIFIED BY 'l59X8bHfO07FIBWY08Z98';
+GRANT ALL PRIVILEGES ON mail_logs.* TO 'mail_logs'@'localhost';
+FLUSH PRIVILEGES;
+USE mail_logs;
+CREATE TABLE IF NOT EXISTS spam_scores (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    ts DATETIME NOT NULL,
+    score FLOAT NOT NULL,
+    message_id VARCHAR(255) NOT NULL,
+    sender VARCHAR(255) DEFAULT NULL,
+    recipients TEXT,
+    subject TEXT,
+    KEY(message_id),
+    KEY(ts)
+);
+ALTER TABLE spam_scores ADD COLUMN IF NOT EXISTS sender VARCHAR(255);
+ALTER TABLE spam_scores ADD COLUMN IF NOT EXISTS recipients TEXT;
+ALTER TABLE spam_scores ADD COLUMN IF NOT EXISTS subject TEXT;
+EOF
+
+# Install systemd service to continually backfill
+SERVICE_FILE=/etc/systemd/system/spam_score_tracker.service
+cat > "$SERVICE_FILE" <<SERVICE
+[Unit]
+Description=Spam Score Tracker
+After=network.target mysql.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 $PLUGIN_DIR/scripts/spam_score_tool.py follow
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl enable --now spam_score_tracker.service || true
+fi
 
 exit 0

--- a/spam_score_tracker/scripts/spam_score_tool.py
+++ b/spam_score_tracker/scripts/spam_score_tool.py
@@ -1,76 +1,179 @@
 #!/usr/bin/env python3
-import re, os, glob, gzip, argparse
+import re, os, glob, gzip, argparse, time, subprocess
 from datetime import datetime, timedelta
 import mysql.connector
 
-# ———— CONFIGURE ME ————
+# —— CONFIGURE ME ——
 DB_CONFIG = {
     'host':     '127.0.0.1',
-    'user':     'your_db_user',
-    'password': 'your_db_pass',
+    'user':     'mail_logs',
+    'password': 'l59X8bHfO07FIBWY08Z98',
     'database': 'mail_logs',
 }
-LOG_GLOB = "/var/log/mail.log*"
+LOG_FILES = ["/var/log/exim/mainlog", "/var/log/mail.log"]
 TIMEZONE = None  # if you need to localize; otherwise leave None
-# ————————————————————
+# ————————————————
 
-LINE_RE = re.compile(
-    r"^(?P<ts>\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}).*spamd: result: [NY]\s+"
-    r"(?P<score>[\d.]+)/\d+\.\d+.*mid=<(?P<mid>[^>]+)>"
-)
+# regexes converted from the PHP parser
+RECEIVED_RE  = re.compile(r'^(?P<ts>\S+\s+\S+)\s+(?P<id>\S+)\s+<=\s+(?P<from>\S+).*\[(?P<ip>[^\]]+)\]')
+SUBJECT_RE   = re.compile(r'T="([^"]*)"')
+MSGID_RE     = re.compile(r'id=([^\s]+)')
+SIZE_RE      = re.compile(r'S=(\d+)')
+RCPT_RE      = re.compile(r'^(?P<ts>\S+\s+\S+)\s+(?P<id>\S+)\s+=>\s+(?P<to>\S+)')
+COMPL_RE     = re.compile(r'^(?P<ts>\S+\s+\S+)\s+(?P<id>\S+)\s+Completed')
+REJ_RE       = re.compile(r'^(?P<ts>\S+\s+\S+)\s+(?P<id>\S+).*rejected', re.I)
+SPAMCHECK_RE = re.compile(r'^(?P<ts>\S+\s+\S+)\s+(?P<id>\S+)\s+.*spamcheck.*score=([\d\.\-]+)(?:.*tests=([A-Za-z0-9_,-]+))?', re.I)
+SPAMD_MID_RE = re.compile(r'^(?P<ts>\w{3}\s+\d+\s+\d+:\d+:\d+).*spamd: result:.*?\s(-?[\d\.]+)\s-\s*([A-Za-z0-9_,-]+).*mid=<([^>]+)>', re.I)
+SPAMD_RE     = re.compile(r'^(?P<ts>\w{3}\s+\d+\s+\d+:\d+:\d+).*spamd: result:.*?\s(-?[\d\.]+)\s-\s*([A-Za-z0-9_,-]+)', re.I)
+
 
 def connect_db():
     return mysql.connector.connect(**DB_CONFIG)
 
+
 def parse_ts(ts_str, year=None):
-    # e.g. "Jul  8 10:56:44"
     dt = datetime.strptime(ts_str, "%b %d %H:%M:%S")
     return dt.replace(year=year or datetime.now().year)
 
-def iterate_logs():
-    """Yield (ts:datetime, score:float, mid:str) from all log files."""
-    for fn in sorted(glob.glob(LOG_GLOB)):
-        opener = gzip.open if fn.endswith(".gz") else open
+
+def parse_logs(files):
+    messages = {}
+    mid_map = {}
+    pending = {}
+    current_id = None
+    for fn in sorted(sum([glob.glob(f+"*") for f in files], [])):
+        opener = gzip.open if fn.endswith('.gz') else open
         try:
-            with opener(fn, "rt", errors="ignore") as f:
+            with opener(fn, 'rt', errors='ignore') as f:
                 for line in f:
-                    m = LINE_RE.match(line)
-                    if not m:
+                    m = RECEIVED_RE.search(line)
+                    if m:
+                        id_ = m.group('id')
+                        current_id = id_
+                        msg = messages.setdefault(id_, {'to': []})
+                        msg['time'] = parse_ts(m.group('ts'))
+                        msg['from'] = m.group('from')
+                        msg['ip'] = m.group('ip')
+                        s = SUBJECT_RE.search(line)
+                        if s:
+                            msg['subject'] = s.group(1)
+                        mi = MSGID_RE.search(line)
+                        if mi:
+                            msg['msgid'] = mi.group(1)
+                            mid_map[mi.group(1)] = id_
+                            if mi.group(1) in pending:
+                                for sa in pending[mi.group(1)]:
+                                    msg['time'] = msg.get('time') or parse_ts(sa['time'])
+                                    msg['score'] = float(sa['score'])
+                                    msg['tests'] = sa['tests']
+                                del pending[mi.group(1)]
+                        sz = SIZE_RE.search(line)
+                        if sz:
+                            msg['size'] = sz.group(1)
                         continue
-                    ts = parse_ts(m.group("ts"))
-                    score = float(m.group("score"))
-                    mid   = m.group("mid")
-                    yield ts, score, mid
+                    m = RCPT_RE.search(line)
+                    if m:
+                        id_ = m.group('id')
+                        current_id = id_
+                        msg = messages.setdefault(id_, {'to': []})
+                        msg.setdefault('to', []).append(m.group('to'))
+                        continue
+                    m = COMPL_RE.search(line)
+                    if m:
+                        id_ = m.group('id')
+                        current_id = id_
+                        msg = messages.setdefault(id_, {'to': []})
+                        msg.setdefault('action', 'delivered')
+                        continue
+                    m = REJ_RE.search(line)
+                    if m:
+                        id_ = m.group('id')
+                        current_id = id_
+                        msg = messages.setdefault(id_, {'to': []})
+                        msg['action'] = 'rejected'
+                        continue
+                    m = SPAMCHECK_RE.search(line)
+                    if m:
+                        id_ = m.group('id')
+                        current_id = id_
+                        msg = messages.setdefault(id_, {'to': []})
+                        msg['time'] = msg.get('time') or parse_ts(m.group('ts'))
+                        msg['score'] = float(m.group(3))
+                        if m.group(4):
+                            msg['tests'] = m.group(4)
+                        msg['spamline'] = line.strip()
+                        continue
+                    m = SPAMD_MID_RE.search(line)
+                    if m:
+                        mid = m.group(4)
+                        info = {'time': m.group('ts'), 'score': m.group(2), 'tests': m.group(3)}
+                        if mid in mid_map:
+                            id_ = mid_map[mid]
+                            msg = messages.setdefault(id_, {'to': []})
+                            msg['time'] = msg.get('time') or parse_ts(m.group('ts'))
+                            msg['score'] = float(m.group(2))
+                            msg['tests'] = m.group(3)
+                            msg['spamline'] = line.strip()
+                        elif current_id:
+                            id_ = current_id
+                            msg = messages.setdefault(id_, {'to': []})
+                            msg['time'] = msg.get('time') or parse_ts(m.group('ts'))
+                            msg['score'] = float(m.group(2))
+                            msg['tests'] = m.group(3)
+                            msg['spamline'] = line.strip()
+                        else:
+                            pending.setdefault(mid, []).append(info)
+                        continue
+                    m = SPAMD_RE.search(line)
+                    if m and current_id:
+                        id_ = current_id
+                        msg = messages.setdefault(id_, {'to': []})
+                        msg['time'] = msg.get('time') or parse_ts(m.group('ts'))
+                        msg['score'] = float(m.group(2))
+                        msg['tests'] = m.group(3)
+                        msg['spamline'] = line.strip()
+                        continue
         except FileNotFoundError:
             continue
+    return messages
+
+
+def generate_entries():
+    msgs = parse_logs(LOG_FILES)
+    for msg in msgs.values():
+        if 'score' in msg and 'msgid' in msg:
+            yield {
+                'ts': msg['time'],
+                'score': msg['score'],
+                'message_id': msg['msgid'],
+                'sender': msg.get('from'),
+                'recipients': ','.join(msg.get('to', [])),
+                'subject': msg.get('subject'),
+            }
+
 
 def backfill():
     cnx = connect_db()
     cur = cnx.cursor()
-    seen = set()
-    for ts, score, mid in iterate_logs():
-        key = (mid, ts)
-        if key in seen:
-            continue
-        seen.add(key)
-        # check before insert
+    for entry in generate_entries():
         cur.execute(
             "SELECT 1 FROM spam_scores WHERE message_id=%s AND ts=%s",
-            (mid, ts)
+            (entry['message_id'], entry['ts'])
         )
         if cur.fetchone():
             continue
         cur.execute(
-            "INSERT INTO spam_scores (ts, score, message_id) VALUES (%s,%s,%s)",
-            (ts, score, mid)
+            "INSERT INTO spam_scores (ts, score, message_id, sender, recipients, subject)"
+            " VALUES (%s,%s,%s,%s,%s,%s)",
+            (entry['ts'], entry['score'], entry['message_id'], entry['sender'], entry['recipients'], entry['subject'])
         )
         cnx.commit()
-        print(f"[+] backfilled {ts} {score:.2f} {mid}")
+        print(f"[+] backfilled {entry['ts']} {entry['score']:.2f} {entry['message_id']}")
     cur.close()
     cnx.close()
 
+
 def query(mid, time_str, tol_minutes=1):
-    # parse the user-provided time; support "YYYY/mmdd HH:MM" or "YYYY/MM/DD HH:MM"
     for fmt in ("%Y/%m%d %H:%M", "%Y/%m/%d %H:%M"):
         try:
             dt = datetime.strptime(time_str, fmt)
@@ -81,59 +184,54 @@ def query(mid, time_str, tol_minutes=1):
         raise SystemExit("❌ time format must be e.g. 2025/0708 10:56 or 2025/07/08 10:56")
     cnx = connect_db()
     cur = cnx.cursor()
-    # 1) try DB
     cur.execute(
-        "SELECT ts, score FROM spam_scores "
+        "SELECT ts, score, sender, recipients, subject FROM spam_scores "
         "WHERE message_id=%s AND ts BETWEEN %s AND %s",
         (mid, dt - timedelta(minutes=tol_minutes), dt + timedelta(minutes=tol_minutes))
     )
     row = cur.fetchone()
     if row:
         print(f"✅ Found in DB: {row[0]} → score={row[1]:.2f}")
+        cur.close(); cnx.close();
         return
-
-    # 2) scan logs
-    for ts, score, m2 in iterate_logs():
-        if m2 == mid and abs((ts - dt).total_seconds()) <= tol_minutes * 60:
-            print(f"🔍 Found in logs: {ts} → score={score:.2f}; inserting into DB")
+    for entry in generate_entries():
+        if entry['message_id'] == mid and abs((entry['ts'] - dt).total_seconds()) <= tol_minutes * 60:
+            print(f"🔍 Found in logs: {entry['ts']} → score={entry['score']:.2f}; inserting into DB")
             cur.execute(
-                "INSERT INTO spam_scores (ts, score, message_id) VALUES (%s,%s,%s)",
-                (ts, score, mid)
+                "INSERT INTO spam_scores (ts, score, message_id, sender, recipients, subject)"
+                " VALUES (%s,%s,%s,%s,%s,%s)",
+                (entry['ts'], entry['score'], entry['message_id'], entry['sender'], entry['recipients'], entry['subject'])
             )
             cnx.commit()
-            cur.close()
-            cnx.close()
+            cur.close(); cnx.close();
             return
-
     print("⚠️  Not found within ±1 min in logs or DB.")
-    cur.close()
-    cnx.close()
+    cur.close(); cnx.close()
+
+
+def follow(interval=60):
+    while True:
+        backfill()
+        time.sleep(interval)
+
 
 def main():
     p = argparse.ArgumentParser(prog="spam_score_tool.py")
     sub = p.add_subparsers(dest="cmd", required=True)
     q = sub.add_parser("query", help="Look up one message-ID + timestamp")
-    q.add_argument("--mid",   required=True, help="Full Message-ID, no <>")
-    q.add_argument("--time",  required=True,
-                   help="YYYY/mmdd HH:MM or YYYY/MM/DD HH:MM")
-    b = sub.add_parser("backfill", help="Scan all existing logs and populate DB")
+    q.add_argument("--mid", required=True, help="Full Message-ID, no <>")
+    q.add_argument("--time", required=True, help="YYYY/mmdd HH:MM or YYYY/MM/DD HH:MM")
+    sub.add_parser("backfill", help="Scan all existing logs and populate DB")
+    sub.add_parser("follow", help="Continuously update DB from logs")
     args = p.parse_args()
-
     if args.cmd == "backfill":
         backfill()
     elif args.cmd == "query":
         query(args.mid, args.time)
+    elif args.cmd == "follow":
+        follow()
     else:
         p.print_help()
 
 if __name__ == "__main__":
     main()
-
-
-# 1) Backfill once on first install:
-#spam_score_tool.py backfill
-
-# 2) On-demand lookup by message-ID + time:
-#spam_score_tool.py query \
-#  --mid "CAMyS0vHooAGpXc5MrN=kmVXXSvtZ-d=3HZYSR80taqPtwNOnGQ@mail.gmail.com" \
-#  --time "2025/07/08 10:56"


### PR DESCRIPTION
## Summary
- switch PHP page to query the MySQL database
- extend Python tool to store sender/recipient/subject and provide a follow mode
- create systemd service and update SQL schema in the installer
- document the new workflow
- add a paginated UI with selectable page size

## Testing
- `php -l spam_score_tracker/public_html/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce789e3dc8331a77d0a08632264ba