### PR TITLE
Add log snippet viewer and use DA mysql credentials

### DIFF
--- a/spam_score_tracker/README.md
+++ b/spam_score_tracker/README.md
@@ -7,7 +7,7 @@ This plugin provides a simple interface for DirectAdmin administrators to review
 ## Installation
 
 1. Copy the `spam_score_tracker` directory to `/usr/local/directadmin/plugins/`.
-2. Run the provided `scripts/install.sh` script from inside the directory. The script creates the log folder, installs Python and required modules, sets up the `mail_logs` database (user `mail_logs`, password `l59X8bHfO07FIBWY08Z98`), and installs a systemd unit to keep the database updated from the mail logs.
+2. Run the provided `scripts/install.sh` script from inside the directory. The script creates the log folder, installs Python and required modules, reads MySQL credentials from `/usr/local/directadmin/conf/mysql.conf` to set up the `mail_logs` database (user `mail_logs`, password `l59X8bHfO07FIBWY08Z98`), and installs a systemd unit to keep the database updated from the mail logs.
 3. Ensure the directory ownership is `diradmin:diradmin` if not already set.
 4. Log in to DirectAdmin as admin and navigate to *Plugins* to enable **SpamScoreTracker**.
 
@@ -15,7 +15,7 @@ To remove the plugin cleanly, run `./scripts/uninstall.sh` from the plugin direc
 
 The included Python script continuously tails `/var/log/exim/mainlog` and `/var/log/mail.log` and stores each message's score along with the sender, recipients and subject in a MySQL table. The PHP interface simply reads from this database, so no log parsing is done on each page load.
 
-The web interface lets you choose how many results to display per page and offers page numbers to navigate through the history.
+The web interface lets you choose how many results to display per page and offers page numbers to navigate through the history. Each entry includes a **View** link which shows 20 lines of log context around the spam-check entry for that message.
 
 ### Packaging
 

--- a/spam_score_tracker/scripts/install.sh
+++ b/spam_score_tracker/scripts/install.sh
@@ -36,7 +36,23 @@ EOF
 fi
 
 # Create MySQL database, user, and table if they don't exist
-mysql -u root <<'EOF'
+MYSQL_CONF=/usr/local/directadmin/conf/mysql.conf
+if [ -r "$MYSQL_CONF" ]; then
+    DB_USER=$(grep -m1 '^user=' "$MYSQL_CONF" | cut -d= -f2)
+    DB_PASS=$(grep -m1 '^passwd=' "$MYSQL_CONF" | cut -d= -f2)
+    DB_HOST=$(grep -m1 '^host=' "$MYSQL_CONF" | cut -d= -f2)
+    DB_PORT=$(grep -m1 '^port=' "$MYSQL_CONF" | cut -d= -f2)
+    DB_SOCK=$(grep -m1 '^socket=' "$MYSQL_CONF" | cut -d= -f2)
+    MYSQL="mysql -u$DB_USER -p$DB_PASS"
+    [ -n "$DB_HOST" ] && MYSQL="$MYSQL -h $DB_HOST"
+    [ -n "$DB_SOCK" ] && MYSQL="$MYSQL --socket=$DB_SOCK"
+    if [ -n "$DB_PORT" ] && [ "$DB_PORT" != "0" ]; then
+        MYSQL="$MYSQL -P $DB_PORT"
+    fi
+else
+    MYSQL="mysql -u root"
+fi
+$MYSQL <<'EOF'
 CREATE DATABASE IF NOT EXISTS mail_logs CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 CREATE USER IF NOT EXISTS 'mail_logs'@'localhost' IDENTIFIED BY 'l59X8bHfO07FIBWY08Z98';
 GRANT ALL PRIVILEGES ON mail_logs.* TO 'mail_logs'@'localhost';


### PR DESCRIPTION
## Summary
- pull MySQL credentials from `/usr/local/directadmin/conf/mysql.conf`
- add "View" links to see 20 lines of log context
- document the new behaviour

## Testing
- `php -l spam_score_tracker/public_html/index.php`

------
https://chatgpt.com/codex/tasks/task_e_686d3836e158833193c29d2ef18e7382